### PR TITLE
chore: monorepo scaffold and documentation alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+dist
+coverage
+.env

--- a/README.md
+++ b/README.md
@@ -2,29 +2,52 @@
 
 Datewise generates a curated date itinerary (2–4 stops) for couples in Singapore based on start MRT/area, time window, walking tolerance, budget, date style, and vibe. It integrates Google Places + Directions for venues/routes and Eventbrite for events.
 
-## Tech Stack
+## Project Goal
+- Singapore-only itinerary generation for couples.
+- V1 focus: deterministic, high-quality planning and shareable itineraries.
+
+## Monorepo structure
+- `apps/web`: Next.js + TypeScript frontend
+- `apps/api`: NestJS + TypeScript backend
+- `packages/shared`: shared types and Zod schemas
+
+## Planned Stack
 - Web: Next.js + TypeScript + Tailwind + shadcn/ui + TanStack Query
 - API: NestJS + TypeScript + Prisma
 - Data: Postgres (persistence), Redis (cache + rate limiting)
 
-## External APIs
+## Planned External APIs
 - Google Places API (places, details, photos, reviews)
 - Google Directions API (routing + walking distance)
 - Google Geocoding API (MRT/area to lat/lng when needed)
 - Eventbrite API (events near coordinates + time window)
 
-## Local Setup
+## Local Setup (Scaffold)
 1) Copy env:
-   - cp .env.example .env
-2) Start dependencies (recommended):
-   - docker compose up -d (or run Postgres + Redis locally)
-3) Install:
-   - npm install
-4) Run:
-   - npm run dev
+   - `cp .env.example .env`
+2) Install dependencies:
+   - `npm install`
+3) Start both apps:
+   - `npm run dev`
+
+### Run apps individually
+- Web: `npm run dev:web`
+- API: `npm run dev:api`
+
+## Roadmap (V1)
+- Input capture and validation
+- Candidate discovery + normalization
+- Dynamic tagging heuristics
+- Scoring and itinerary assembly
+- Reroll/swap, persistence, and caching
+
+## Current status
+- Monorepo/workspaces scaffold is in place.
+- No external API integrations yet.
+- No business logic yet.
 
 ## Docs
-See /docs for product, requirements, API, scoring, data model, and runbook.
+See `/docs` for product, requirements, API, scoring, data model, and runbook.
 
 ## Security
 All external API keys are backend-only. Frontend never calls external APIs directly.

--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@datewise/api",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "nest start --watch",
+    "build": "nest build",
+    "start": "node dist/main.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@nestjs/common": "10.4.7",
+    "@nestjs/core": "10.4.7",
+    "@nestjs/platform-express": "10.4.7",
+    "reflect-metadata": "0.2.2",
+    "rxjs": "7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "10.4.5",
+    "typescript": "5.5.4",
+    "@types/node": "20.14.12"
+  }
+}

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from "@nestjs/common";
+
+@Controller()
+export class AppController {
+  @Get("health")
+  health(): { status: string } {
+    return { status: "ok" };
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+
+@Module({
+  imports: [],
+  controllers: [AppController]
+})
+export class AppModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,10 @@
+import "reflect-metadata";
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+
+void bootstrap();

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main>
+      <h1>Datewise Web</h1>
+      <p>Next.js workspace is initialized.</p>
+    </main>
+  );
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@datewise/web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "5.5.4",
+    "@types/node": "20.14.12",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "noEmit": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "datewise",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "concurrently \"npm run dev:web\" \"npm run dev:api\"",
+    "dev:web": "npm run dev --workspace @datewise/web",
+    "dev:api": "npm run dev --workspace @datewise/api",
+    "build": "npm run build --workspaces --if-present",
+    "typecheck": "npm run typecheck --workspaces --if-present"
+  },
+  "devDependencies": {
+    "concurrently": "9.0.1"
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@datewise/shared",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "5.5.4"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./schemas.js";

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const healthResponseSchema = z.object({
+  status: z.literal("ok")
+});
+
+export type HealthResponse = z.infer<typeof healthResponseSchema>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- Refines the npm workspaces monorepo scaffold with three packages:
  - apps/web (Next.js + TypeScript)
  - apps/api (NestJS + TypeScript)
  - packages/shared (shared Zod schemas/types)
- Keeps README product context intact (goal, planned stack, external APIs, roadmap) while ensuring install/run commands match the scaffold.
- Provides root workspace scripts for running web and api together, plus per-app dev scripts.
- Keeps the codebase intentionally minimal: no external API integrations and no business logic yet.

## Scope
- [x] Backend
- [x] Frontend
- [x] Shared package
- [x] Docs only

## Key Decisions
- Used npm workspaces at the root to align with the requested monorepo structure.
- Kept TypeScript strict via a shared base tsconfig for consistency across packages.
- Added only minimal starter app code (health route/page) to validate structure without introducing product logic too early.
- Preserved README strategic context and only adjusted setup/run instructions to reflect actual scaffolded commands.

## API / Docs
- [ ] Updated docs/04_API_SPEC.md if API changed
- [x] Updated packages/shared schemas/types if needed

## Testing
- [ ] Unit tests added/updated
- [x] Manual smoke test described below

### Manual smoke test steps
1. Run npm install at repo root.
2. Run npm run dev and confirm both apps/web and apps/api dev servers start.
3. Verify web app loads and GET /health on API returns { "status": "ok" }.

## Notes for Reviewer (@codex review)
Focus on:
- Contract correctness vs docs
- Input validation and error handling
- Cache-first behavior for external APIs
- No secrets exposed to frontend