### PR TITLE
feat: start location autocomplete

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
+import { PlacesController } from './places/places.controller';
+import { PlacesService } from './places/places.service';
 
 @Module({
   imports: [],
-  controllers: [AppController],
-  providers: [],
+  controllers: [AppController, PlacesController],
+  providers: [PlacesService],
 })
 export class AppModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
   await app.listen(3001);
 }
 

--- a/apps/api/src/places/cache.ts
+++ b/apps/api/src/places/cache.ts
@@ -1,0 +1,34 @@
+export interface CacheStore {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T, ttlMs: number): void;
+}
+
+type CacheEntry<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+export class InMemoryCacheStore implements CacheStore {
+  private readonly store = new Map<string, CacheEntry<unknown>>();
+
+  get<T>(key: string): T | undefined {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return undefined;
+    }
+
+    if (entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return undefined;
+    }
+
+    return entry.value as T;
+  }
+
+  set<T>(key: string, value: T, ttlMs: number): void {
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + ttlMs,
+    });
+  }
+}

--- a/apps/api/src/places/http.ts
+++ b/apps/api/src/places/http.ts
@@ -1,0 +1,45 @@
+import { HttpException, HttpStatus, Logger } from '@nestjs/common';
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_RETRIES = 2;
+
+const logger = new Logger('HttpClient');
+
+export async function fetchJsonWithRetry<T>(url: string): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Google Places API failed (${response.status}): ${body}`);
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      lastError = error;
+      logger.warn(`External call failed on attempt ${attempt + 1}: ${String(error)}`);
+      if (attempt === MAX_RETRIES) {
+        break;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw new HttpException(
+    {
+      code: 'EXTERNAL_SERVICE_ERROR',
+      message: 'Failed to fetch Google Places data.',
+      details: String(lastError),
+    },
+    HttpStatus.BAD_GATEWAY,
+  );
+}

--- a/apps/api/src/places/places.controller.ts
+++ b/apps/api/src/places/places.controller.ts
@@ -1,0 +1,46 @@
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import {
+  PlaceDetailsQuerySchema,
+  PlaceDetailsResponse,
+  PlacesAutocompleteQuerySchema,
+  PlacesAutocompleteResponse,
+} from '@datewise/shared';
+import { ZodError } from 'zod';
+import { PlacesService } from './places.service';
+
+@Controller('/v1/places')
+export class PlacesController {
+  constructor(private readonly placesService: PlacesService) {}
+
+  @Get('/autocomplete')
+  async autocomplete(@Query('q') q: string): Promise<PlacesAutocompleteResponse> {
+    const { q: query } = this.parseOrThrowBadRequest(() => PlacesAutocompleteQuerySchema.parse({ q }));
+    return this.placesService.autocomplete(query);
+  }
+
+  @Get('/details')
+  async details(@Query('placeId') placeId: string): Promise<PlaceDetailsResponse> {
+    const { placeId: parsedPlaceId } = this.parseOrThrowBadRequest(() =>
+      PlaceDetailsQuerySchema.parse({ placeId }),
+    );
+    return this.placesService.details(parsedPlaceId);
+  }
+
+  private parseOrThrowBadRequest<T>(parse: () => T): T {
+    try {
+      return parse();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new BadRequestException({
+          message: 'Invalid request query parameters',
+          errors: error.issues.map((issue) => ({
+            path: issue.path.join('.'),
+            message: issue.message,
+          })),
+        });
+      }
+
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/places/places.service.ts
+++ b/apps/api/src/places/places.service.ts
@@ -1,0 +1,167 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import {
+  PlaceDetailsResponse,
+  PlaceDetailsResponseSchema,
+  PlacesAutocompleteResponse,
+  PlacesAutocompleteResponseSchema,
+} from '@datewise/shared';
+import { z } from 'zod';
+import { CacheStore, InMemoryCacheStore } from './cache';
+import { fetchJsonWithRetry } from './http';
+
+const GOOGLE_AUTOCOMPLETE_RESPONSE_SCHEMA = z.object({
+  predictions: z.array(
+    z.object({
+      place_id: z.string().min(1),
+      structured_formatting: z.object({
+        main_text: z.string().min(1),
+        secondary_text: z.string().optional(),
+      }),
+    }),
+  ),
+  status: z.string(),
+});
+
+const GOOGLE_PLACE_DETAILS_RESPONSE_SCHEMA = z.object({
+  result: z.object({
+    place_id: z.string().min(1),
+    name: z.string().min(1),
+    formatted_address: z.string().min(1),
+    geometry: z.object({
+      location: z.object({
+        lat: z.number(),
+        lng: z.number(),
+      }),
+    }),
+    types: z.array(z.string()),
+  }),
+  status: z.string(),
+});
+
+@Injectable()
+export class PlacesService {
+  private readonly cache: CacheStore = new InMemoryCacheStore();
+
+  async autocomplete(query: string): Promise<PlacesAutocompleteResponse> {
+    const cacheKey = `autocomplete:${query}`;
+    const cached = this.cache.get<PlacesAutocompleteResponse>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const response = await fetchJsonWithRetry<unknown>(this.buildAutocompleteUrl(query));
+    const parsed = GOOGLE_AUTOCOMPLETE_RESPONSE_SCHEMA.safeParse(response);
+    if (!parsed.success) {
+      throw new HttpException(
+        {
+          code: 'INVALID_EXTERNAL_RESPONSE',
+          message: 'Invalid autocomplete response from Google Places.',
+          details: parsed.error.flatten(),
+        },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    if (parsed.data.status !== 'OK' && parsed.data.status !== 'ZERO_RESULTS') {
+      throw new HttpException(
+        {
+          code: 'EXTERNAL_SERVICE_ERROR',
+          message: `Google Places autocomplete status: ${parsed.data.status}`,
+        },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    const normalized = PlacesAutocompleteResponseSchema.parse({
+      suggestions: parsed.data.predictions.map((prediction) => ({
+        placeId: prediction.place_id,
+        primaryText: prediction.structured_formatting.main_text,
+        secondaryText: prediction.structured_formatting.secondary_text ?? '',
+      })),
+    });
+
+    this.cache.set(cacheKey, normalized, 60_000);
+    return normalized;
+  }
+
+  async details(placeId: string): Promise<PlaceDetailsResponse> {
+    const cacheKey = `details:${placeId}`;
+    const cached = this.cache.get<PlaceDetailsResponse>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const response = await fetchJsonWithRetry<unknown>(this.buildDetailsUrl(placeId));
+    const parsed = GOOGLE_PLACE_DETAILS_RESPONSE_SCHEMA.safeParse(response);
+    if (!parsed.success) {
+      throw new HttpException(
+        {
+          code: 'INVALID_EXTERNAL_RESPONSE',
+          message: 'Invalid place details response from Google Places.',
+          details: parsed.error.flatten(),
+        },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    if (parsed.data.status !== 'OK') {
+      throw new HttpException(
+        {
+          code: 'EXTERNAL_SERVICE_ERROR',
+          message: `Google Places details status: ${parsed.data.status}`,
+        },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    const normalized = PlaceDetailsResponseSchema.parse({
+      placeId: parsed.data.result.place_id,
+      name: parsed.data.result.name,
+      formattedAddress: parsed.data.result.formatted_address,
+      lat: parsed.data.result.geometry.location.lat,
+      lng: parsed.data.result.geometry.location.lng,
+      types: parsed.data.result.types,
+    });
+
+    this.cache.set(cacheKey, normalized, 5 * 60_000);
+    return normalized;
+  }
+
+  private buildAutocompleteUrl(query: string): string {
+    return this.buildUrl('https://maps.googleapis.com/maps/api/place/autocomplete/json', {
+      input: query,
+      key: this.getApiKey(),
+      components: 'country:sg',
+      language: 'en',
+      types: 'geocode',
+    });
+  }
+
+  private buildDetailsUrl(placeId: string): string {
+    return this.buildUrl('https://maps.googleapis.com/maps/api/place/details/json', {
+      place_id: placeId,
+      key: this.getApiKey(),
+      fields: 'place_id,name,formatted_address,geometry,types',
+    });
+  }
+
+  private buildUrl(baseUrl: string, params: Record<string, string>): string {
+    const searchParams = new URLSearchParams(params);
+    return `${baseUrl}?${searchParams.toString()}`;
+  }
+
+  private getApiKey(): string {
+    const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+    if (!apiKey) {
+      throw new HttpException(
+        {
+          code: 'MISSING_CONFIGURATION',
+          message: 'GOOGLE_PLACES_API_KEY is required.',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    return apiKey;
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,13 +1,149 @@
-// import { VibeSchema } from '@datewise/shared';
+'use client';
 
-// const vibes = VibeSchema.options;
+import { useEffect, useMemo, useState } from 'react';
+import {
+  PlaceDetailsResponse,
+  PlaceDetailsResponseSchema,
+  PlacesAutocompleteResponse,
+  PlacesAutocompleteResponseSchema,
+} from '@datewise/shared';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:3001';
 
 export default function HomePage() {
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<PlacesAutocompleteResponse['suggestions']>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedOrigin, setSelectedOrigin] = useState<PlaceDetailsResponse | null>(null);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedQuery(query.trim());
+    }, 300);
+
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
+  useEffect(() => {
+    if (debouncedQuery.length < 2) {
+      setSuggestions([]);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadSuggestions() {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetch(
+          `${API_BASE_URL}/v1/places/autocomplete?q=${encodeURIComponent(debouncedQuery)}`,
+        );
+
+        if (!response.ok) {
+          throw new Error('Unable to load suggestions.');
+        }
+
+        const body = (await response.json()) as unknown;
+        const parsed = PlacesAutocompleteResponseSchema.parse(body);
+        if (!cancelled) {
+          setSuggestions(parsed.suggestions);
+        }
+      } catch {
+        if (!cancelled) {
+          setSuggestions([]);
+          setError('Failed to load place suggestions. Please try again.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadSuggestions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery]);
+
+  const hasSuggestions = useMemo(() => suggestions.length > 0, [suggestions]);
+
+  async function onSelectSuggestion(placeId: string) {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await fetch(
+        `${API_BASE_URL}/v1/places/details?placeId=${encodeURIComponent(placeId)}`,
+      );
+
+      if (!response.ok) {
+        throw new Error('Unable to fetch place details.');
+      }
+
+      const body = (await response.json()) as unknown;
+      const details = PlaceDetailsResponseSchema.parse(body);
+      setSelectedOrigin(details);
+      setQuery(details.name);
+      setSuggestions([]);
+    } catch {
+      setError('Failed to fetch selected place details.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
-    <main style={{ fontFamily: 'sans-serif', padding: '2rem' }}>
+    <main style={{ fontFamily: 'sans-serif', padding: '2rem', maxWidth: '42rem' }}>
       <h1>Datewise Web</h1>
-      <p>Monorepo bootstrap complete. No business logic added yet.</p>
-      {/* <p>Supported vibes schema: {vibes.join(', ')}</p> */}
+      <p>Search for your Singapore origin to begin planning your date itinerary.</p>
+
+      <label htmlFor="origin-search" style={{ display: 'block', marginBottom: '0.5rem' }}>
+        Origin search
+      </label>
+      <input
+        id="origin-search"
+        type="text"
+        placeholder="Search Singapore location..."
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        style={{ width: '100%', padding: '0.5rem', marginBottom: '0.75rem' }}
+      />
+
+      {loading ? <p>Loading...</p> : null}
+      {error ? <p style={{ color: 'crimson' }}>{error}</p> : null}
+
+      {hasSuggestions ? (
+        <ul style={{ border: '1px solid #ddd', borderRadius: '0.25rem', padding: '0.5rem' }}>
+          {suggestions.map((suggestion) => (
+            <li key={suggestion.placeId} style={{ listStyle: 'none', marginBottom: '0.5rem' }}>
+              <button
+                type="button"
+                style={{ width: '100%', textAlign: 'left', padding: '0.5rem' }}
+                onClick={() => {
+                  void onSelectSuggestion(suggestion.placeId);
+                }}
+              >
+                <strong>{suggestion.primaryText}</strong>
+                <br />
+                <span>{suggestion.secondaryText}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {selectedOrigin ? (
+        <section style={{ marginTop: '1rem', padding: '0.75rem', border: '1px solid #e5e7eb' }}>
+          <h2 style={{ marginTop: 0 }}>Selected origin</h2>
+          <pre style={{ margin: 0 }}>{JSON.stringify(selectedOrigin, null, 2)}</pre>
+        </section>
+      ) : null}
     </main>
   );
 }

--- a/docs/04_API_SPEC.md
+++ b/docs/04_API_SPEC.md
@@ -1,5 +1,38 @@
 # API Spec (v1)
 
+## GET /v1/places/autocomplete
+Query
+- `q`: string (required, min length 2, max length 120)
+
+Response
+```json
+{
+  "suggestions": [
+    {
+      "placeId": "string",
+      "primaryText": "string",
+      "secondaryText": "string"
+    }
+  ]
+}
+```
+
+## GET /v1/places/details
+Query
+- `placeId`: string (required, non-empty)
+
+Response
+```json
+{
+  "placeId": "string",
+  "name": "string",
+  "formattedAddress": "string",
+  "lat": 1.300,
+  "lng": 103.800,
+  "types": ["string"]
+}
+```
+
 ## POST /v1/itineraries/generate
 Request
 {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,5 +10,37 @@ export const PlanRequestSchema = z.object({
   vibe: VibeSchema,
 });
 
+export const PlacesAutocompleteQuerySchema = z.object({
+  q: z.string().min(2).max(120),
+});
+
+export const PlacesSuggestionSchema = z.object({
+  placeId: z.string().min(1),
+  primaryText: z.string().min(1),
+  secondaryText: z.string().default(''),
+});
+
+export const PlacesAutocompleteResponseSchema = z.object({
+  suggestions: z.array(PlacesSuggestionSchema),
+});
+
+export const PlaceDetailsQuerySchema = z.object({
+  placeId: z.string().min(1),
+});
+
+export const PlaceDetailsResponseSchema = z.object({
+  placeId: z.string().min(1),
+  name: z.string().min(1),
+  formattedAddress: z.string().min(1),
+  lat: z.number(),
+  lng: z.number(),
+  types: z.array(z.string()),
+});
+
 export type Vibe = z.infer<typeof VibeSchema>;
 export type PlanRequest = z.infer<typeof PlanRequestSchema>;
+export type PlacesAutocompleteQuery = z.infer<typeof PlacesAutocompleteQuerySchema>;
+export type PlacesSuggestion = z.infer<typeof PlacesSuggestionSchema>;
+export type PlacesAutocompleteResponse = z.infer<typeof PlacesAutocompleteResponseSchema>;
+export type PlaceDetailsQuery = z.infer<typeof PlaceDetailsQuerySchema>;
+export type PlaceDetailsResponse = z.infer<typeof PlaceDetailsResponseSchema>;


### PR DESCRIPTION
## Summary
What does this PR change?
- Implements Google Places origin selection end-to-end by replacing the static origin flow with a debounced autocomplete UX and new backend places endpoints.
- Adds GET /v1/places/autocomplete?q=... and GET /v1/places/details?placeId=...
- Integrates Google Places with Singapore restriction (components=country:sg)
- Enforces cache-first behavior with an in-memory cache interface
- Applies Zod validation to request inputs and external API responses
- Adds timeout (5s) + retry (max 2) wrapper for external calls with structured error mapping
- Keeps Google API key backend-only (GOOGLE_PLACES_API_KEY)
- Updates shared schemas in packages/shared
- Updates docs/04_API_SPEC.md
- Updates frontend with 300ms debounced autocomplete input, selectable suggestions, and selected origin state

## Scope
- [x] Backend
- [x] Frontend
- [x] Shared package
- [x] Docs only

## Key Decisions
List any important design choices or trade-offs.
- Cache-first via interface + in-memory implementation: keeps logic deterministic/testable now, while allowing Redis/etc. later without controller changes.
- Validation at boundaries: shared Zod schemas validate API contract; additional Zod schemas validate Google payloads before mapping.
- Centralized external HTTP behavior: timeout/retry/error mapping handled in one utility to keep service code focused on domain mapping.
- Singapore-only constraint at provider call: enforced using Google components=country:sg parameter for autocomplete.
- Backend-only secret handling: frontend only calls internal API; never receives or stores Google API key.

## API / Docs
- [x] Updated docs/04_API_SPEC.md if API changed
- [x] Updated packages/shared schemas/types if needed

## Testing
- [ ] Unit tests added/updated
- [x] Manual smoke test described below

### Manual smoke test steps
1. Set GOOGLE_PLACES_API_KEY for API and start services (api + web).
2. In web app, type at least 2 characters in origin field and confirm suggestions appear after ~300ms debounce.
3. Click a suggestion and verify selected origin details (placeId, name, formattedAddress, lat, lng, types) are fetched and stored/displayed.
4. Repeat the same query/place to confirm responses are served successfully with cache-first flow (no UX regression).
5. Validate error handling by using an invalid/missing API key and confirm structured backend errors + frontend fallback messaging.

## Notes for Reviewer (@codex review)
Focus on:
- Contract correctness vs docs
- Input validation and error handling
- Cache-first behavior for external APIs
- No secrets exposed to frontend