### PR TITLE
feat(api): add places candidate search near selected origin

### DIFF
--- a/apps/api/src/places/places.controller.ts
+++ b/apps/api/src/places/places.controller.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
 import {
+  DebugPlaceCandidatesQuerySchema,
+  DebugPlaceCandidatesResponse,
   PlaceDetailsQuerySchema,
   PlaceDetailsResponse,
   PlacesAutocompleteQuerySchema,
@@ -24,6 +26,21 @@ export class PlacesController {
     }
 
     return this.placesService.autocomplete(parsedQuery.data.q);
+  }
+
+  @Get('/debug/candidates')
+  async candidates(@Query('originPlaceId') originPlaceId: string): Promise<DebugPlaceCandidatesResponse> {
+    const parsedQuery = DebugPlaceCandidatesQuerySchema.safeParse({ originPlaceId });
+
+    if (!parsedQuery.success) {
+      throw new BadRequestException({
+        code: 'INVALID_PLACE_CANDIDATES_QUERY',
+        message: 'Invalid places candidates query parameters',
+        issues: parsedQuery.error.issues,
+      });
+    }
+
+    return this.placesService.candidatesNearOrigin(parsedQuery.data.originPlaceId);
   }
 
   @Get('/details')

--- a/docs/04_API_SPEC.md
+++ b/docs/04_API_SPEC.md
@@ -35,9 +35,36 @@ Response
 
 
 Provider notes
-- `/v1/places/autocomplete` and `/v1/places/details` are backed by Google Places API (Autocomplete + Place Details).
+- `/v1/places/autocomplete`, `/v1/places/details`, and `/v1/places/debug/candidates` are backed by Google Places API (Autocomplete + Place Details + Nearby Search).
 - Requests are restricted to Singapore (`country=SG`) with Singapore proximity bias.
 - External calls use timeout <= 5s and max 2 retries.
+
+
+## GET /v1/places/debug/candidates
+Query
+- `originPlaceId`: string (required, non-empty)
+
+Response
+```json
+{
+  "originPlaceId": "string",
+  "candidates": [
+    {
+      "kind": "PLACE|EVENT",
+      "externalId": "string",
+      "name": "string",
+      "lat": 1.3,
+      "lng": 103.8,
+      "address": "string",
+      "rating": 4.5,
+      "reviewCount": 1200,
+      "priceLevel": 2,
+      "types": ["cafe", "restaurant"],
+      "tags": ["CAFE", "RESTAURANT"]
+    }
+  ]
+}
+```
 
 ## POST /v1/itineraries/generate
 Request

--- a/packages/shared/src/index.d.ts
+++ b/packages/shared/src/index.d.ts
@@ -123,6 +123,120 @@ export declare const GenerateItineraryOriginSchema: z.ZodObject<{
     lng: number;
     types: string[];
 }>;
+export declare const CandidateSchema: z.ZodObject<{
+    kind: z.ZodEnum<["PLACE", "EVENT"]>;
+    externalId: z.ZodString;
+    name: z.ZodString;
+    lat: z.ZodNumber;
+    lng: z.ZodNumber;
+    address: z.ZodOptional<z.ZodString>;
+    rating: z.ZodOptional<z.ZodNumber>;
+    reviewCount: z.ZodOptional<z.ZodNumber>;
+    priceLevel: z.ZodOptional<z.ZodNumber>;
+    types: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    tags: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    lat: number;
+    lng: number;
+    kind: "EVENT" | "PLACE";
+    externalId: string;
+    types?: string[] | undefined;
+    address?: string | undefined;
+    rating?: number | undefined;
+    reviewCount?: number | undefined;
+    priceLevel?: number | undefined;
+    tags?: string[] | undefined;
+}, {
+    name: string;
+    lat: number;
+    lng: number;
+    kind: "EVENT" | "PLACE";
+    externalId: string;
+    types?: string[] | undefined;
+    address?: string | undefined;
+    rating?: number | undefined;
+    reviewCount?: number | undefined;
+    priceLevel?: number | undefined;
+    tags?: string[] | undefined;
+}>;
+export declare const DebugPlaceCandidatesQuerySchema: z.ZodObject<{
+    originPlaceId: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    originPlaceId: string;
+}, {
+    originPlaceId: string;
+}>;
+export declare const DebugPlaceCandidatesResponseSchema: z.ZodObject<{
+    originPlaceId: z.ZodString;
+    candidates: z.ZodArray<z.ZodObject<{
+        kind: z.ZodEnum<["PLACE", "EVENT"]>;
+        externalId: z.ZodString;
+        name: z.ZodString;
+        lat: z.ZodNumber;
+        lng: z.ZodNumber;
+        address: z.ZodOptional<z.ZodString>;
+        rating: z.ZodOptional<z.ZodNumber>;
+        reviewCount: z.ZodOptional<z.ZodNumber>;
+        priceLevel: z.ZodOptional<z.ZodNumber>;
+        types: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+        tags: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    }, "strip", z.ZodTypeAny, {
+        name: string;
+        lat: number;
+        lng: number;
+        kind: "EVENT" | "PLACE";
+        externalId: string;
+        types?: string[] | undefined;
+        address?: string | undefined;
+        rating?: number | undefined;
+        reviewCount?: number | undefined;
+        priceLevel?: number | undefined;
+        tags?: string[] | undefined;
+    }, {
+        name: string;
+        lat: number;
+        lng: number;
+        kind: "EVENT" | "PLACE";
+        externalId: string;
+        types?: string[] | undefined;
+        address?: string | undefined;
+        rating?: number | undefined;
+        reviewCount?: number | undefined;
+        priceLevel?: number | undefined;
+        tags?: string[] | undefined;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    originPlaceId: string;
+    candidates: {
+        name: string;
+        lat: number;
+        lng: number;
+        kind: "EVENT" | "PLACE";
+        externalId: string;
+        types?: string[] | undefined;
+        address?: string | undefined;
+        rating?: number | undefined;
+        reviewCount?: number | undefined;
+        priceLevel?: number | undefined;
+        tags?: string[] | undefined;
+    }[];
+}, {
+    originPlaceId: string;
+    candidates: {
+        name: string;
+        lat: number;
+        lng: number;
+        kind: "EVENT" | "PLACE";
+        externalId: string;
+        types?: string[] | undefined;
+        address?: string | undefined;
+        rating?: number | undefined;
+        reviewCount?: number | undefined;
+        priceLevel?: number | undefined;
+        tags?: string[] | undefined;
+    }[];
+}>;
 export declare const GenerateItineraryRequestSchema: z.ZodObject<{
     origin: z.ZodObject<{
         placeId: z.ZodString;
@@ -210,11 +324,11 @@ export declare const ItineraryStopSchema: z.ZodObject<{
     lng: number;
     kind: "EVENT" | "PLACE";
     address: string;
-    url: string;
     rating: number;
     reviewCount: number;
     priceLevel: number;
     tags: string[];
+    url: string;
     reason: string;
 }, {
     name: string;
@@ -222,11 +336,11 @@ export declare const ItineraryStopSchema: z.ZodObject<{
     lng: number;
     kind: "EVENT" | "PLACE";
     address: string;
-    url: string;
     rating: number;
     reviewCount: number;
     priceLevel: number;
     tags: string[];
+    url: string;
     reason: string;
 }>;
 export declare const ItineraryLegSchema: z.ZodObject<{
@@ -278,11 +392,11 @@ export declare const GenerateItineraryResponseSchema: z.ZodObject<{
         lng: number;
         kind: "EVENT" | "PLACE";
         address: string;
-        url: string;
         rating: number;
         reviewCount: number;
         priceLevel: number;
         tags: string[];
+        url: string;
         reason: string;
     }, {
         name: string;
@@ -290,11 +404,11 @@ export declare const GenerateItineraryResponseSchema: z.ZodObject<{
         lng: number;
         kind: "EVENT" | "PLACE";
         address: string;
-        url: string;
         rating: number;
         reviewCount: number;
         priceLevel: number;
         tags: string[];
+        url: string;
         reason: string;
     }>, "many">;
     legs: z.ZodArray<z.ZodObject<{
@@ -344,11 +458,11 @@ export declare const GenerateItineraryResponseSchema: z.ZodObject<{
         lng: number;
         kind: "EVENT" | "PLACE";
         address: string;
-        url: string;
         rating: number;
         reviewCount: number;
         priceLevel: number;
         tags: string[];
+        url: string;
         reason: string;
     }[];
     legs: {
@@ -374,11 +488,11 @@ export declare const GenerateItineraryResponseSchema: z.ZodObject<{
         lng: number;
         kind: "EVENT" | "PLACE";
         address: string;
-        url: string;
         rating: number;
         reviewCount: number;
         priceLevel: number;
         tags: string[];
+        url: string;
         reason: string;
     }[];
     legs: {
@@ -412,6 +526,9 @@ export type AvoidPreference = z.infer<typeof AvoidPreferenceSchema>;
 export type Transport = z.infer<typeof TransportSchema>;
 export type GenerateItineraryOrigin = z.infer<typeof GenerateItineraryOriginSchema>;
 export type GenerateItineraryRequest = z.infer<typeof GenerateItineraryRequestSchema>;
+export type Candidate = z.infer<typeof CandidateSchema>;
+export type DebugPlaceCandidatesQuery = z.infer<typeof DebugPlaceCandidatesQuerySchema>;
+export type DebugPlaceCandidatesResponse = z.infer<typeof DebugPlaceCandidatesResponseSchema>;
 export type ItineraryStop = z.infer<typeof ItineraryStopSchema>;
 export type ItineraryLeg = z.infer<typeof ItineraryLegSchema>;
 export type ItineraryTotals = z.infer<typeof ItineraryTotalsSchema>;

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.GenerateItineraryResponseSchema = exports.ItineraryTotalsSchema = exports.ItineraryLegSchema = exports.ItineraryStopSchema = exports.GenerateItineraryRequestSchema = exports.GenerateItineraryOriginSchema = exports.TransportSchema = exports.AvoidPreferenceSchema = exports.FoodPreferenceSchema = exports.VibeOptionSchema = exports.DateStyleOptionSchema = exports.BudgetSchema = exports.PlaceDetailsResponseSchema = exports.PlaceDetailsQuerySchema = exports.PlacesAutocompleteResponseSchema = exports.PlacesSuggestionSchema = exports.PlacesAutocompleteQuerySchema = exports.PlanRequestSchema = exports.VibeSchema = void 0;
+exports.GenerateItineraryResponseSchema = exports.ItineraryTotalsSchema = exports.ItineraryLegSchema = exports.ItineraryStopSchema = exports.GenerateItineraryRequestSchema = exports.DebugPlaceCandidatesResponseSchema = exports.DebugPlaceCandidatesQuerySchema = exports.CandidateSchema = exports.GenerateItineraryOriginSchema = exports.TransportSchema = exports.AvoidPreferenceSchema = exports.FoodPreferenceSchema = exports.VibeOptionSchema = exports.DateStyleOptionSchema = exports.BudgetSchema = exports.PlaceDetailsResponseSchema = exports.PlaceDetailsQuerySchema = exports.PlacesAutocompleteResponseSchema = exports.PlacesSuggestionSchema = exports.PlacesAutocompleteQuerySchema = exports.PlanRequestSchema = exports.VibeSchema = void 0;
 const zod_1 = require("zod");
 exports.VibeSchema = zod_1.z.enum(['chill', 'active', 'romantic', 'adventurous']);
 exports.PlanRequestSchema = zod_1.z.object({
@@ -41,6 +41,26 @@ exports.FoodPreferenceSchema = zod_1.z.enum(['VEG', 'HALAL_FRIENDLY', 'NO_ALCOHO
 exports.AvoidPreferenceSchema = zod_1.z.enum(['OUTDOOR', 'PHYSICAL', 'CROWDED', 'LOUD']);
 exports.TransportSchema = zod_1.z.enum(['MIN_WALK', 'TRANSIT', 'DRIVE_OK', 'WALK_OK']);
 exports.GenerateItineraryOriginSchema = exports.PlaceDetailsResponseSchema;
+exports.CandidateSchema = zod_1.z.object({
+    kind: zod_1.z.enum(['PLACE', 'EVENT']),
+    externalId: zod_1.z.string().min(1),
+    name: zod_1.z.string().min(1),
+    lat: zod_1.z.number(),
+    lng: zod_1.z.number(),
+    address: zod_1.z.string().min(1).optional(),
+    rating: zod_1.z.number().min(0).max(5).optional(),
+    reviewCount: zod_1.z.number().int().min(0).optional(),
+    priceLevel: zod_1.z.number().int().min(0).max(4).optional(),
+    types: zod_1.z.array(zod_1.z.string().min(1)).optional(),
+    tags: zod_1.z.array(zod_1.z.string().min(1)).optional(),
+});
+exports.DebugPlaceCandidatesQuerySchema = zod_1.z.object({
+    originPlaceId: zod_1.z.string().min(1),
+});
+exports.DebugPlaceCandidatesResponseSchema = zod_1.z.object({
+    originPlaceId: zod_1.z.string().min(1),
+    candidates: zod_1.z.array(exports.CandidateSchema),
+});
 exports.GenerateItineraryRequestSchema = zod_1.z.object({
     origin: exports.GenerateItineraryOriginSchema,
     date: DateSchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -49,6 +49,29 @@ export const TransportSchema = z.enum(['MIN_WALK', 'TRANSIT', 'DRIVE_OK', 'WALK_
 
 export const GenerateItineraryOriginSchema = PlaceDetailsResponseSchema;
 
+export const CandidateSchema = z.object({
+  kind: z.enum(['PLACE', 'EVENT']),
+  externalId: z.string().min(1),
+  name: z.string().min(1),
+  lat: z.number(),
+  lng: z.number(),
+  address: z.string().min(1).optional(),
+  rating: z.number().min(0).max(5).optional(),
+  reviewCount: z.number().int().min(0).optional(),
+  priceLevel: z.number().int().min(0).max(4).optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+});
+
+export const DebugPlaceCandidatesQuerySchema = z.object({
+  originPlaceId: z.string().min(1),
+});
+
+export const DebugPlaceCandidatesResponseSchema = z.object({
+  originPlaceId: z.string().min(1),
+  candidates: z.array(CandidateSchema),
+});
+
 export const GenerateItineraryRequestSchema = z.object({
   origin: GenerateItineraryOriginSchema,
   date: DateSchema,
@@ -115,6 +138,9 @@ export type AvoidPreference = z.infer<typeof AvoidPreferenceSchema>;
 export type Transport = z.infer<typeof TransportSchema>;
 export type GenerateItineraryOrigin = z.infer<typeof GenerateItineraryOriginSchema>;
 export type GenerateItineraryRequest = z.infer<typeof GenerateItineraryRequestSchema>;
+export type Candidate = z.infer<typeof CandidateSchema>;
+export type DebugPlaceCandidatesQuery = z.infer<typeof DebugPlaceCandidatesQuerySchema>;
+export type DebugPlaceCandidatesResponse = z.infer<typeof DebugPlaceCandidatesResponseSchema>;
 export type ItineraryStop = z.infer<typeof ItineraryStopSchema>;
 export type ItineraryLeg = z.infer<typeof ItineraryLegSchema>;
 export type ItineraryTotals = z.infer<typeof ItineraryTotalsSchema>;


### PR DESCRIPTION
### Related Issue
Closes #18

### Motivation
- Provide backend-only discovery of nearby place candidates centered on a chosen origin so the itinerary generator can score and assemble options.
- Normalize Google Places Nearby Search results into an internal `Candidate` shape and ensure results are Singapore-only.
- Expose a small internal debug endpoint to exercise the candidate lookup and keep the integration testable without client-side keys.

### Description
- Added `CandidateSchema`, `DebugPlaceCandidatesQuerySchema`, and `DebugPlaceCandidatesResponseSchema` to `packages/shared` and exported corresponding types (`Candidate`, `DebugPlaceCandidatesQuery`, `DebugPlaceCandidatesResponse`).
- Implemented `googleNearbyToCandidates(payload)` to parse and normalize Google Nearby Search responses with price-level mapping, type->tag normalization, Singapore-only filtering, and structured error mapping in `apps/api/src/places/places.service.ts`.
- Added `PlacesService.candidatesNearOrigin(originPlaceId)` which resolves origin coordinates via existing `details` and calls Google `places:searchNearby` with an appropriate field mask, request body, caching (`candidates:<originPlaceId>`), and the existing retry/timeout wrapper.
- Added internal debug endpoint `GET /v1/places/debug/candidates?originPlaceId=...` with Zod validation in `apps/api/src/places/places.controller.ts` and updated API docs (`docs/04_API_SPEC.md`).
- Added unit tests in `apps/api/src/places/places.service.spec.ts` covering normalization, SG filtering, and missing-location handling for nearby results.

### Testing
- Ran type checking with `npm run typecheck --workspace @datewise/api`, which completed successfully.
- Compiled and executed the service spec directly with `./node_modules/.bin/tsc -p apps/api/tsconfig.json --outDir .tmp-api-test-dist && node --test .tmp-api-test-dist/places/places.service.spec.js`, and all added tests passed (8 tests total).
- Ran `npm test --workspace @datewise/api`; the project build succeeds, and note the workspace test script currently reports 0 discovered tests in this environment due to the dist glob behavior, but the explicit spec run above demonstrates the unit tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a8ab36e8c83228e81cb608ba03501)