### PR TITLE
Strengthen auth flows for Google, protected routes, and logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ npm run build
 ```
 
 ## Auth behavior
-- Frontend primary auth uses Datewise API endpoints (`/auth/signup`, `/auth/login`) for local email/password flows.
+- Frontend auth supports email/password (`/auth/signup`, `/auth/login`) and Google Sign-In (`/auth/google` with Google ID token).
+- Protected frontend pages (`/planner`, `/profile`, `/saved`) redirect to `/login` when no session exists in local storage.
+- Logout is available from the Profile page and clears local session state.
 - API uses in-memory users in local dev; if the API restarts, sign in again to refresh session state.
 - API can also validate Supabase bearer tokens via `/auth/v1/user` when Supabase env vars are configured.
 

--- a/apps/api/src/auth/service.spec.ts
+++ b/apps/api/src/auth/service.spec.ts
@@ -95,6 +95,66 @@ test('allows updating display name after signup', async () => {
   db.saved.clear();
 });
 
+test('supports signup and login flow for email accounts', async () => {
+  const auth = new AuthService();
+  const { user: signedUp } = await auth.signup({ email: 'email-user@example.com', password: 'pw123' });
+  const { token, user: loggedIn } = await auth.login({ email: 'email-user@example.com', password: 'pw123' });
+  const me = await auth.getMe(token);
+
+  assert.equal(loggedIn.id, signedUp.id);
+  assert.equal(me.email, 'email-user@example.com');
+  assert.equal(me.id, signedUp.id);
+
+  await assert.rejects(() => auth.signup({ email: 'email-user@example.com', password: 'pw123' }), /already registered/);
+
+  db.users.clear();
+  db.itineraries.clear();
+  db.saved.clear();
+});
+
+test('google login updates existing profile while preserving avatar when omitted', async () => {
+  const auth = new AuthService();
+  const originalFetch = global.fetch;
+
+  let responseMode: 'first' | 'second' = 'first';
+  global.fetch = (async () => {
+    if (responseMode === 'first') {
+      return new Response(
+        JSON.stringify({
+          email: 'repeat-google@example.com',
+          email_verified: 'true',
+          name: 'Original Name',
+          picture: 'https://images.example.com/original.png',
+          iss: 'https://accounts.google.com',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        email: 'repeat-google@example.com',
+        email_verified: 'true',
+        name: 'Updated Name',
+        iss: 'https://accounts.google.com',
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  }) as typeof fetch;
+
+  const firstLogin = await auth.googleLogin({ idToken: 'first-token' });
+  responseMode = 'second';
+  const secondLogin = await auth.googleLogin({ idToken: 'second-token' });
+
+  assert.equal(firstLogin.user.id, secondLogin.user.id);
+  assert.equal(secondLogin.user.displayName, 'Updated Name');
+  assert.equal(secondLogin.user.profileImage, 'https://images.example.com/original.png');
+
+  global.fetch = originalFetch;
+  db.users.clear();
+  db.itineraries.clear();
+  db.saved.clear();
+});
+
 
 test('returns local session expired when token belongs to cleared in-memory user', async () => {
   const auth = new AuthService();

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,17 +1,72 @@
 'use client';
 
-import { useState } from 'react';
-import { signIn, signUp } from '../../lib/auth';
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { signIn, signInWithGoogle, signUp } from '../../lib/auth';
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        id?: {
+          initialize: (options: { client_id: string; callback: (response: { credential?: string }) => void }) => void;
+          renderButton: (element: HTMLElement, options: { theme: string; size: string; text: string }) => void;
+        };
+      };
+    };
+  }
+}
 
 export default function LoginPage() {
+  const searchParams = useSearchParams();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
+  const googleButtonRef = useRef<HTMLDivElement | null>(null);
+  const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+  const nextPath = searchParams.get('next') || '/planner';
+
+  useEffect(() => {
+    if (!googleClientId || !googleButtonRef.current) return;
+
+    const initializeGoogleButton = () => {
+      if (!window.google?.accounts?.id || !googleButtonRef.current) return;
+      window.google.accounts.id.initialize({
+        client_id: googleClientId,
+        callback: async ({ credential }) => {
+          if (!credential) return setMessage('Google login failed: missing credential token.');
+          try {
+            await signInWithGoogle(credential);
+            location.href = nextPath;
+          } catch (error) {
+            setMessage(`Google login failed: ${error instanceof Error ? error.message : 'unknown error'}`);
+          }
+        },
+      });
+
+      googleButtonRef.current.innerHTML = '';
+      window.google.accounts.id.renderButton(googleButtonRef.current, { theme: 'outline', size: 'large', text: 'continue_with' });
+    };
+
+    if (window.google?.accounts?.id) {
+      initializeGoogleButton();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.onload = initializeGoogleButton;
+    document.body.appendChild(script);
+    return () => script.remove();
+  }, [googleClientId, nextPath]);
 
   return (
     <main className="mx-auto grid max-w-xl gap-3 p-6">
       <h1 className="text-3xl font-bold">Datewise Login</h1>
-      <p className="text-slate-300">Sign up and login with email and password. Set your username from the profile page.</p>
+      <p className="text-slate-300">Sign up and login with email/password or Google. Set your username from the profile page.</p>
+      {googleClientId ? <div ref={googleButtonRef} className="w-full" /> : <p className="text-amber-300 text-sm">Set NEXT_PUBLIC_GOOGLE_CLIENT_ID to enable Google login.</p>}
       <input placeholder="Email" value={email} onChange={(event) => setEmail(event.target.value)} />
       <input placeholder="Password" type="password" value={password} onChange={(event) => setPassword(event.target.value)} />
       <div className="flex gap-2">
@@ -20,7 +75,7 @@ export default function LoginPage() {
             try {
               await signUp(email, password);
               setMessage('Signup successful. Redirecting to planner...');
-              location.href = '/planner';
+              location.href = nextPath;
             } catch (error) {
               setMessage(`Signup failed: ${error instanceof Error ? error.message : 'unknown error'}`);
             }
@@ -32,7 +87,7 @@ export default function LoginPage() {
           onClick={async () => {
             try {
               await signIn(email, password);
-              location.href = '/planner';
+              location.href = nextPath;
             } catch (error) {
               setMessage(`Login failed: ${error instanceof Error ? error.message : 'unknown error'}`);
             }

--- a/apps/web/src/app/planner/page.tsx
+++ b/apps/web/src/app/planner/page.tsx
@@ -4,12 +4,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { detectConflict, CORE_GROUPS, SUBGROUPS, type SlotType } from '@datewise/shared';
 import { apiBaseUrl, readSession } from '../../lib/auth';
 
-declare global {
-  interface Window {
-    google?: any;
-  }
-}
-
 type PlanSlot = {
   slotIndex: number;
   slotType: SlotType;
@@ -34,6 +28,7 @@ const allSelections = [...CORE_GROUPS, ...Object.values(SUBGROUPS).flat()] as Sl
 const defaultStart: StartPoint = { name: 'Marina Bay Sands', latitude: 1.2834, longitude: 103.8607, placeId: 'default-marina-bay-sands' };
 
 export default function PlannerPage() {
+  const [token, setToken] = useState<string | null>(null);
   const [startPoint, setStartPoint] = useState<StartPoint>(defaultStart);
   const [startQuery, setStartQuery] = useState(defaultStart.name);
   const [predictions, setPredictions] = useState<Prediction[]>([]);
@@ -51,20 +46,29 @@ export default function PlannerPage() {
   const placesDivRef = useRef<HTMLDivElement | null>(null);
 
   const conflicts = useMemo(() => detectConflict(slots, avoidSlots), [slots, avoidSlots]);
-  const token = readSession()?.accessToken;
   const googleMapsKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+  useEffect(() => {
+    const session = readSession();
+    if (!session?.accessToken) {
+      location.href = '/login?next=/planner';
+      return;
+    }
+    setToken(session.accessToken);
+  }, []);
 
   useEffect(() => {
     if (!googleMapsKey) return;
 
     function initServices() {
-      if (!window.google?.maps?.places || !placesDivRef.current) return;
-      autocompleteServiceRef.current = new window.google.maps.places.AutocompleteService();
-      placesServiceRef.current = new window.google.maps.places.PlacesService(placesDivRef.current);
+      const googleMaps = (window as Window & { google?: any }).google;
+      if (!googleMaps?.maps?.places || !placesDivRef.current) return;
+      autocompleteServiceRef.current = new googleMaps.maps.places.AutocompleteService();
+      placesServiceRef.current = new googleMaps.maps.places.PlacesService(placesDivRef.current);
       setGoogleReady(true);
     }
 
-    if (window.google?.maps?.places) {
+    if ((window as Window & { google?: any }).google?.maps?.places) {
       initServices();
       return;
     }
@@ -173,6 +177,14 @@ export default function PlannerPage() {
     }
     setError('');
     setInfo(isPublic ? 'Saved to public itineraries.' : 'Saved to your profile itineraries.');
+  }
+
+  if (!token) {
+    return (
+      <main className="mx-auto max-w-4xl space-y-4 p-6">
+        <p className="text-slate-300">Redirecting to login...</p>
+      </main>
+    );
   }
 
   return (

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,21 +1,30 @@
 'use client';
 
-import { useState } from 'react';
-import { apiBaseUrl, readSession } from '../../lib/auth';
+import { useEffect, useState } from 'react';
+import { apiBaseUrl, readSession, signOut } from '../../lib/auth';
 
 type User = { id: string; email: string; displayName: string; profileImage: string | null };
 type Itinerary = { id: string; createdAt: string; isPublic: boolean; result: Array<{ place: { name: string } }> };
 type Saved = { id: string; sourceItineraryId: string; createdAt: string; snapshot: { id: string } };
 
 export default function ProfilePage() {
+  const [token, setToken] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [mine, setMine] = useState<Itinerary[]>([]);
   const [saved, setSaved] = useState<Saved[]>([]);
   const [displayName, setDisplayName] = useState('');
   const [error, setError] = useState('');
 
+  useEffect(() => {
+    const session = readSession();
+    if (!session?.accessToken) {
+      location.href = '/login?next=/profile';
+      return;
+    }
+    setToken(session.accessToken);
+  }, []);
+
   async function load() {
-    const token = readSession()?.accessToken;
     if (!token) return setError('Please login first');
 
     const headers = { authorization: `Bearer ${token}` };
@@ -36,7 +45,6 @@ export default function ProfilePage() {
   }
 
   async function saveDisplayName() {
-    const token = readSession()?.accessToken;
     if (!token) return setError('Please login first');
 
     const response = await fetch(`${apiBaseUrl()}/auth/display-name`, {
@@ -54,10 +62,28 @@ export default function ProfilePage() {
     setError('');
   }
 
+  if (!token) {
+    return (
+      <main className="mx-auto max-w-3xl space-y-4 p-6">
+        <p className="text-slate-300">Redirecting to login...</p>
+      </main>
+    );
+  }
+
   return (
     <main className="mx-auto max-w-3xl space-y-4 p-6">
       <h1 className="text-3xl font-bold">Profile</h1>
-      <button onClick={load}>Refresh profile data</button>
+      <div className="flex gap-2">
+        <button onClick={load}>Refresh profile data</button>
+        <button
+          onClick={() => {
+            signOut();
+            location.href = '/login';
+          }}
+        >
+          Logout
+        </button>
+      </div>
       {error && <p className="text-rose-300">{error}</p>}
 
       {user && (

--- a/apps/web/src/app/saved/page.tsx
+++ b/apps/web/src/app/saved/page.tsx
@@ -1,6 +1,28 @@
+'use client';
+
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { readSession } from '../../lib/auth';
 
 export default function SavedPage() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!readSession()?.accessToken) {
+      location.href = '/login?next=/saved';
+      return;
+    }
+    setReady(true);
+  }, []);
+
+  if (!ready) {
+    return (
+      <main className="mx-auto max-w-3xl space-y-4 p-6">
+        <p className="text-slate-300">Redirecting to login...</p>
+      </main>
+    );
+  }
+
   return (
     <main className="mx-auto max-w-3xl space-y-4 p-6">
       <h1 className="text-3xl font-bold">Saved Itineraries</h1>

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -64,3 +64,14 @@ export async function signIn(email: string, password: string): Promise<AuthSessi
   writeSession(session);
   return session;
 }
+
+export async function signInWithGoogle(idToken: string): Promise<AuthSession> {
+  const data = await apiPost('/auth/google', { idToken });
+  const session = sessionFromAuthResponse(data);
+  writeSession(session);
+  return session;
+}
+
+export function signOut() {
+  clearSession();
+}


### PR DESCRIPTION
### Motivation
- The issue requested end-to-end verification and fixes for Google OAuth and email/password flows, session persistence, logout, protected routes, and user record creation/update behavior.  
- The frontend lacked Google Sign-In wiring, protected-route guards, and an explicit logout action which made some auth flows incomplete.  

### Description
- Add Google Sign-In support on the login page using Google Identity Services and exchange the returned ID token with the API at `POST /auth/google`, and make the UI honor `?next=` return redirects.  
- Extend frontend auth utilities with `signInWithGoogle` and `signOut` to store/clear the same session in `localStorage`.  
- Add client-side guards to protect `/planner`, `/profile`, and `/saved` so unauthenticated users are redirected to `/login?next=...` and see a short redirecting state.  
- Add a Logout button on the Profile page that calls `signOut()` and redirects to `/login`.  
- Add tests in `apps/api/src/auth/service.spec.ts` to cover email signup/login, duplicate-email rejection, and repeated Google login behavior that updates display name while preserving an existing avatar when a later token omits `picture`.  
- Update `README.md` auth section to reflect Google login, protected-route behavior, and logout.  

Summary:  
1) What changed: frontend Google login, `signInWithGoogle`/`signOut`, protected-route guards, logout UI, and extra auth unit tests and README updates.  
2) Why: to provide complete end-to-end Google and email auth flows, ensure session handling and redirects behave correctly, and cover edge cases in tests.  
3) Remaining limitations: Google login requires `NEXT_PUBLIC_GOOGLE_CLIENT_ID` to be configured and the dev API uses in-memory users so API restarts still require re-login (existing design). 

### Testing
- Ran API unit tests with `npm run test --workspace @datewise/api`, which executed the auth and itinerary suites; all tests passed (`# pass 15`, `# fail 0`).  
- Ran frontend typecheck with `npm run typecheck --workspace @datewise/web`, which completed successfully (`tsc` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4703e2588322849502e9d5c28221)